### PR TITLE
Update group_name to use cf_pi annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ as follows:
 | cluster_name   | *openshift cluster annotation*                           |
 | partition_name | **blank**                                                |
 | qos_name       | **blank**                                                |
-| account_name   | *PI annotation*                                          |
-| group_name     | *PI annotation*                                          |
+| account_name   | *cf_pi annotation*                                       |
+| group_name     | *cf_pi annotation*                                       |
 | gid_number     | **blank**                                                |
 | user_name      | *openshift namespace*                                    |
 | uid_number     | **blank**                                                |

--- a/openshift_metrics/tests/test_utils.py
+++ b/openshift_metrics/tests/test_utils.py
@@ -423,12 +423,12 @@ class TestWriteMetricsLog(TestCase):
             },
         }
 
-        expected_output = ("0|0|test_cluster_name|||PI1|123||namespace1||1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:01:59|0-0:01:59||COMPLETED|1|10|20|1.0|cpu=20,mem=1.0|cpu=20,mem=1.0|0-0:01:59||pod1\n"
-                           "1|1|test_cluster_name|||PI1|123||namespace1||1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:59|0-0:00:59||COMPLETED|1|20|20|1.0|cpu=20,mem=1.0|cpu=20,mem=1.0|0-0:00:59||pod1\n"
-                           "2|2|test_cluster_name|||PI1|123||namespace1||1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:59|0-0:00:59||COMPLETED|1|20|30|10.0|cpu=30,mem=10.0|cpu=30,mem=10.0|0-0:00:59||pod2\n"
-                           "3|3|test_cluster_name|||PI1|123||namespace1||1969-12-31T19:01:00|1969-12-31T19:01:00|1969-12-31T19:01:00|1969-12-31T19:01:59|0-0:00:59||COMPLETED|1|25|30|10.0|cpu=30,mem=10.0|cpu=30,mem=10.0|0-0:00:59||pod2\n"
-                           "4|4|test_cluster_name|||PI1|123||namespace1||1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:59|0-0:00:59||COMPLETED|1|20|30|10.0|cpu=30,mem=10.0|cpu=30,mem=10.0|0-0:00:59||pod2\n"
-                           "5|5|test_cluster_name|||PI2|456||namespace2||1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:02:59|0-0:02:59||COMPLETED|1|45|50|100.0|cpu=50,mem=100.0|cpu=50,mem=100.0|0-0:02:59||pod3\n")
+        expected_output = ("0|0|test_cluster_name|||PI1|PI1||namespace1||1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:01:59|0-0:01:59||COMPLETED|1|10|20|1.0|cpu=20,mem=1.0|cpu=20,mem=1.0|0-0:01:59||pod1\n"
+                           "1|1|test_cluster_name|||PI1|PI1||namespace1||1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:59|0-0:00:59||COMPLETED|1|20|20|1.0|cpu=20,mem=1.0|cpu=20,mem=1.0|0-0:00:59||pod1\n"
+                           "2|2|test_cluster_name|||PI1|PI1||namespace1||1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:59|0-0:00:59||COMPLETED|1|20|30|10.0|cpu=30,mem=10.0|cpu=30,mem=10.0|0-0:00:59||pod2\n"
+                           "3|3|test_cluster_name|||PI1|PI1||namespace1||1969-12-31T19:01:00|1969-12-31T19:01:00|1969-12-31T19:01:00|1969-12-31T19:01:59|0-0:00:59||COMPLETED|1|25|30|10.0|cpu=30,mem=10.0|cpu=30,mem=10.0|0-0:00:59||pod2\n"
+                           "4|4|test_cluster_name|||PI1|PI1||namespace1||1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:00|1969-12-31T19:02:59|0-0:00:59||COMPLETED|1|20|30|10.0|cpu=30,mem=10.0|cpu=30,mem=10.0|0-0:00:59||pod2\n"
+                           "5|5|test_cluster_name|||PI2|PI2||namespace2||1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:00:00|1969-12-31T19:02:59|0-0:02:59||COMPLETED|1|45|50|100.0|cpu=50,mem=100.0|cpu=50,mem=100.0|0-0:02:59||pod3\n")
 
         tmp_file_name = "%s/test-metrics-%s.log" % (tempfile.gettempdir(), time.time())
         utils.write_metrics_log(test_metrics_dict, tmp_file_name, 'test_cluster_name')

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -115,7 +115,7 @@ def write_metrics_log(metrics_dict, file_name, openshift_cluster_name):
             partition_name = ''
             qos_name = ''
             account_name = cf_pi
-            group_name = cf_project_id
+            group_name = cf_pi
             gid_number = ''
             user_name = namespace
             uid_number = ''


### PR DESCRIPTION
The cf_project_id annotation used is simply a number; this makes the group_name legible.