### PR TITLE
Print namespace name instead of group_name (which could be namespace …

### DIFF
--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -115,7 +115,7 @@ def write_metrics_log(metrics_dict, file_name, openshift_cluster_name):
             partition_name = ''
             qos_name = ''
             account_name = namespace
-            group_name = cf_pi
+            group_name = namespace
             gid_number = cf_project_id
             user_name = cf_pi
             uid_number = cf_project_id


### PR DESCRIPTION
…name when

a PI annotation is not found)

so this field will always be the namespace.

Addresses https://github.com/CCI-MOC/xdmod-cntr/issues/192

@rob-baron please let me know if that's the field you need changed to namespace. 



